### PR TITLE
Fix ZeroDivisionError issue

### DIFF
--- a/sungrowinverter/SungrowInverter.py
+++ b/sungrowinverter/SungrowInverter.py
@@ -302,7 +302,7 @@ class SungrowInverter:
                     for register_calc in calculation_registers:
                         try:
                             self.data[register_calc.key] = eval(register_calc.calculation)
-                        finally:
+                        except ZeroDivisionError:
                             self.data[register_calc.key] = 0
                             
                 try:


### PR DESCRIPTION
Fixed a code issue where data were always set to zero in the finally clause.
Now it only sets data to zero if ZeroDivisionError is caught by calc.
Any other unknown exception is not caught.